### PR TITLE
Set up environment variables to let aws cli access to the object storage environment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,13 @@ gomplate --file /pg_back.conf.tmpl --out /etc/pg_back/pg_back.conf
 echo "${POSTGRES_HOST}:${POSTGRES_PORT}:*:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > ~/.pgpass
 chmod 0600 ~/.pgpass
 
+# Set up environment variables to let aws cli access to the object
+# storage environment that has the backups made by pg_back
+export AWS_ACCESS_KEY_ID="${S3_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${S3_SECRET}"
+export AWS_ENDPOINT_URL="${S3_ENDPOINT}"
+export AWS_DEFAULT_REGION="${S3_REGION}"
+
 if [[ $# -ne 0 ]]; then
     exec "$@"
     exit 0


### PR DESCRIPTION
Set up environment variables to let *aws cli* access to the object storage environment that has the backups made by *pg_back*.

```
$ docker compose build pg_back1
$ docker compose run --rm pg_back1 bash
[+] Creating 2/2
 ✔ Container poc_pg_back_988a0a507908-postgres1-1  Running                                                                                                                                                      0.0s
 ✔ Container poc_pg_back_988a0a507908-minio-1      Running                                                                                                                                                      0.0s
Ad82f268e98a0:/# export | grep "AWS"
declare -x AWS_ACCESS_KEY_ID="admin"
declare -x AWS_DEFAULT_REGION="us-east-1"
declare -x AWS_ENDPOINT_URL="http://minio:9000/"
declare -x AWS_SECRET_ACCESS_KEY="password"
d82f268e98a0:/#
```