### PR TITLE
Use POSTGRES_VERSION to define global postgres version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,9 @@ gomplate --file /pg_back.conf.tmpl --out /etc/pg_back/pg_back.conf
 echo "${POSTGRES_HOST}:${POSTGRES_PORT}:*:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > ~/.pgpass
 chmod 0600 ~/.pgpass
 
+rm -rf /usr/libexec/postgresql
+ln -sf "/usr/libexec/postgresql${POSTGRES_VERSION}" /usr/libexec/postgresql
+
 if [[ $# -ne 0 ]]; then
     exec "$@"
     exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,10 @@ gomplate --file /pg_back.conf.tmpl --out /etc/pg_back/pg_back.conf
 echo "${POSTGRES_HOST}:${POSTGRES_PORT}:*:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > ~/.pgpass
 chmod 0600 ~/.pgpass
 
+if [ ! -d "/usr/libexec/postgresql${POSTGRES_VERSION}" ]; then
+    echo "Error: PostgreSQL ${POSTGRES_VERSION} is not installed or not found in /usr/libexec/"
+    exit 1
+fi
 rm -rf /usr/libexec/postgresql
 ln -sf "/usr/libexec/postgresql${POSTGRES_VERSION}" /usr/libexec/postgresql
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,6 @@ fi
 
 echo "$BACKUP_CRON /usr/local/bin/pg_back" > /main.crontab
 
-
 if [[ "${DISABLE_CRON,,}" == "true" ]] || [[ "${DISABLE_CRON,,}" == "yes" ]] || [[ "${DISABLE_CRON,,}" == "1" ]]; then
     tail -f /dev/null
 else


### PR DESCRIPTION
With this commit two changes:

- `POSTGRES_VERSION` is applied globally inside the container
- container fail to start if `POSTGRES_VERSION` is not installed

```shell
$ docker run --rm -it -e POSTGRES_VERSION=15 docker.io/stephaneklein/pg_back-docker-sidecar psql --version
psql (PostgreSQL) 15.13
$ docker run --rm -it -e POSTGRES_VERSION=16 docker.io/stephaneklein/pg_back-docker-sidecar psql --version
psql (PostgreSQL) 16.9
$ docker run --rm -it -e POSTGRES_VERSION=18 docker.io/stephaneklein/pg_back-docker-sidecar psql --version
Error: PostgreSQL 18 is not installed or not found in /usr/libexec/
```